### PR TITLE
Add profile layout and routing for event hosts

### DIFF
--- a/static/src/content.config.ts
+++ b/static/src/content.config.ts
@@ -30,10 +30,13 @@ const eventinfo = defineCollection({
 });
 const profiles = defineCollection({
 	loader: glob({ base: './src/content/profiles', pattern: '**/*.{md,mdx}' }),
-	schema: z.object({
+	schema: ({image}) => z.object({
 		name: z.string().optional(),
 		role: z.string().optional(),
 		avatar: z.string().optional(),
+		title: z.string().optional(),
+		description: z.string().optional(),
+		heroImage: image().optional(),
 	}),
 });
 

--- a/static/src/content/profiles/DancingSeal.md
+++ b/static/src/content/profiles/DancingSeal.md
@@ -1,0 +1,9 @@
+---
+title: DancingSeal
+description: DancingSeal is a passionate dancer and event host.
+heroImage: ../images/DancingSealHero.jpg
+---
+
+![DancingSeal](../images/DancingSealAvatar.jpg)
+
+DancingSeal is a passionate dancer and event host who loves to bring joy and energy to every event. With years of experience in various dance forms, DancingSeal knows how to get the crowd moving and create an unforgettable experience.

--- a/static/src/content/profiles/FireHeart.md
+++ b/static/src/content/profiles/FireHeart.md
@@ -1,0 +1,9 @@
+---
+title: FireHeart
+description: FireHeart is a dedicated event host with a fiery passion.
+heroImage: ../images/FireHeartHero.jpg
+---
+
+![FireHeart](../images/FireHeartAvatar.jpg)
+
+FireHeart is a dedicated event host with a fiery passion for creating memorable experiences. With a background in event management and a love for bringing people together, FireHeart ensures that every event is a success.

--- a/static/src/content/profiles/FireRoseEarth.md
+++ b/static/src/content/profiles/FireRoseEarth.md
@@ -1,0 +1,9 @@
+---
+title: FireRoseEarth
+description: FireRoseEarth is a dedicated event host with a deep connection to nature.
+heroImage: ../images/FireRoseEarthHero.jpg
+---
+
+![FireRoseEarth](../images/FireRoseEarthAvatar.jpg)
+
+FireRoseEarth is a dedicated event host with a deep connection to nature. With a background in environmental science and a passion for sustainable living, FireRoseEarth brings a unique perspective to every event.

--- a/static/src/content/profiles/LightningStar.md
+++ b/static/src/content/profiles/LightningStar.md
@@ -1,0 +1,9 @@
+---
+title: LightningStar
+description: LightningStar is a dynamic event host with a spark of creativity.
+heroImage: ../images/LightningStarHero.jpg
+---
+
+![LightningStar](../images/LightningStarAvatar.jpg)
+
+LightningStar is a dynamic event host with a spark of creativity. With a background in performing arts and a passion for innovation, LightningStar brings a unique and exciting energy to every event.

--- a/static/src/content/profiles/LionHeart.md
+++ b/static/src/content/profiles/LionHeart.md
@@ -1,0 +1,9 @@
+---
+title: LionHeart
+description: LionHeart is a courageous event host with a heart of gold.
+heroImage: ../images/LionHeartHero.jpg
+---
+
+![LionHeart](../images/LionHeartAvatar.jpg)
+
+LionHeart is a courageous event host with a heart of gold. With a background in community service and a passion for helping others, LionHeart brings warmth and compassion to every event.

--- a/static/src/content/profiles/RainbowStarlight.md
+++ b/static/src/content/profiles/RainbowStarlight.md
@@ -1,0 +1,9 @@
+---
+title: RainbowStarlight
+description: RainbowStarlight is a vibrant event host with a love for colors.
+heroImage: ../images/RainbowStarlightHero.jpg
+---
+
+![RainbowStarlight](../images/RainbowStarlightAvatar.jpg)
+
+RainbowStarlight is a vibrant event host with a love for colors. With a background in art and a passion for creativity, RainbowStarlight brings a unique and colorful energy to every event.

--- a/static/src/layouts/EventPost.astro
+++ b/static/src/layouts/EventPost.astro
@@ -79,8 +79,9 @@ const { title, description, hosts, startDate, endDate, location, heroImage } = A
 										Until <FormattedDate date={endDate} />
 									</div>
 								}
-								@ {location} with {hosts.length>0 && hosts.join(",").replace(/,(?=[^,]*$)/, ' and ')
-								}
+								@ {location} with {hosts.length>0 && hosts.map((host, index) => (
+									<a key={index} href={`/profiles/${host.toLowerCase().replace(/\s+/g, '-')}`}>{host}</a>
+								)).reduce((prev, curr) => [prev, ', ', curr])}
 						</div>
 						<h1>{title}</h1>
 						<hr />
@@ -92,4 +93,3 @@ const { title, description, hosts, startDate, endDate, location, heroImage } = A
 		<Footer />
 	</body>
 </html>
-

--- a/static/src/layouts/ProfileLayout.astro
+++ b/static/src/layouts/ProfileLayout.astro
@@ -1,0 +1,60 @@
+---
+import BaseHead from '../components/BaseHead.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import { Image } from 'astro:assets';
+
+interface Props {
+  name: string;
+  description: string;
+  avatar: string;
+}
+
+const { name, description, avatar } = Astro.props;
+---
+
+<html lang="en">
+  <head>
+    <BaseHead title={name} description={role} />
+    <style>
+      main {
+        width: calc(100% - 2em);
+        max-width: 100%;
+        margin: 0;
+      }
+      .profile {
+        width: 720px;
+        max-width: calc(100% - 2em);
+        margin: auto;
+        padding: 1em;
+        color: rgb(var(--gray-dark));
+        text-align: center;
+      }
+      .profile img {
+        display: block;
+        margin: 0 auto;
+        border-radius: 50%;
+        box-shadow: var(--box-shadow);
+      }
+      .profile h1 {
+        margin: 0.5em 0;
+      }
+      .profile h2 {
+        margin: 0.5em 0;
+        color: rgb(var(--gray));
+      }
+    </style>
+  </head>
+  <body>
+    <Header />
+    <main>
+      <div class="profile">
+        <Image width={200} height={200} src={avatar} alt={name} />
+        <h1>{name}</h1>
+        <h2>{role}</h2>
+        <slot />
+      </div>
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/static/src/layouts/ProfileLayout.astro
+++ b/static/src/layouts/ProfileLayout.astro
@@ -15,7 +15,7 @@ const { name, description, avatar } = Astro.props;
 
 <html lang="en">
   <head>
-    <BaseHead title={name} description={role} />
+    <BaseHead title={name} description={description} />
     <style>
       main {
         width: calc(100% - 2em);
@@ -51,7 +51,7 @@ const { name, description, avatar } = Astro.props;
       <div class="profile">
         <Image width={200} height={200} src={avatar} alt={name} />
         <h1>{name}</h1>
-        <h2>{role}</h2>
+        <h2>{description}</h2>
         <slot />
       </div>
     </main>

--- a/static/src/pages/profiles/[...slug].astro
+++ b/static/src/pages/profiles/[...slug].astro
@@ -10,9 +10,9 @@ if (!profile) {
   throw new Error(`Profile not found for slug: ${slug}`);
 }
 
-const { name, role, avatar } = profile.data;
+const { name, description, avatar } = profile.data;
 ---
 
-<ProfileLayout name={name} role={role} avatar={avatar}>
+<ProfileLayout name={name} description={description} avatar={avatar}>
   <slot />
 </ProfileLayout>

--- a/static/src/pages/profiles/[...slug].astro
+++ b/static/src/pages/profiles/[...slug].astro
@@ -1,0 +1,18 @@
+---
+import { getCollection } from 'astro:content';
+import ProfileLayout from '../../layouts/ProfileLayout.astro';
+
+const profiles = await getCollection('profiles');
+const slug = Astro.url.pathname.split('/').pop();
+const profile = profiles.find((p) => p.slug === slug);
+
+if (!profile) {
+  throw new Error(`Profile not found for slug: ${slug}`);
+}
+
+const { name, role, avatar } = profile.data;
+---
+
+<ProfileLayout name={name} role={role} avatar={avatar}>
+  <slot />
+</ProfileLayout>


### PR DESCRIPTION
Add layout and routing for profiles of event hosts.

* **Profile Layout**: Create `ProfileLayout.astro` to display profile information with imported components and defined props.
* **Profile Routing**: Add `/profiles/[...slug].astro` route to handle profile pages, fetching profile data based on the slug and rendering it using `ProfileLayout`.
* **Content Configuration**: Update `static/src/content.config.ts` to include `title`, `description`, and `heroImage` fields in the `profiles` collection schema.
* **Profile Markdown Files**: Add `title`, `description`, and `heroImage` fields to the frontmatter of `DancingSeal.md`, `FireHeart.md`, `FireRoseEarth.md`, `LightningStar.md`, `LionHeart.md`, and `RainbowStarlight.md`.
* **Event Post Layout**: Update `EventPost.astro` to link the `hosts` field to the corresponding profile pages.

